### PR TITLE
Detach UIScrollView from PullUpController

### DIFF
--- a/PullUpController/PullUpController.swift
+++ b/PullUpController/PullUpController.swift
@@ -332,4 +332,12 @@ extension UIScrollView {
         panGestureRecognizer.addTarget(pullUpController, action: #selector(pullUpController.handleInternalScrollViewPanGestureRecognizer(_:)))
     }
     
+    /**
+	Remove the scroll view from the pull up controller so it no longer moves with the scroll view content.
+	 - parameter pullUpController: the pull up controller to be removed from controlling the scroll view.
+	**/
+	open func detach(from pullUpController: PullUpController) {
+		panGestureRecognizer.removeTarget(pullUpController, action: #selector(pullUpController.handleInternalScrollViewPanGestureRecognizer(_:)))
+	}
+    
 }


### PR DESCRIPTION
A very handy method to detach the scroll view from the pull up controller, so things like pull to refresh can be achieved.